### PR TITLE
Add a warning about promiseTypeSuffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ composeStoreWithMiddleware = applyMiddleware(
   promiseMiddleware,
 )(createStore);
 ```
+NOTE: This library is *not* yet compatible with the `promiseTypeSuffixes` option of `redux-promise-middleware`
 
 ## Usage
 


### PR DESCRIPTION
New to this library, but just wanted to say I wasted some time trying to figure out why my asyncReducer was ignoring the actions, then realised it's because if `promiseTypeSuffixes` are configured differently in `redux-promise-middleware` e.g. I changed them to `["LOADING", "SUCCESS","ERROR"]`, when you create async actions / reducers using this library, the suffixes will not match, since this library hard codes them to `["PENDING","FULFILLED","REJECTED"]`.. hence the autogenerated reducers will just ignore the differently named actions and you'll be left wondering why your state isn't changing! 